### PR TITLE
Fix issues obtaining the JWT

### DIFF
--- a/src/southern_company_api/parser.py
+++ b/src/southern_company_api/parser.py
@@ -137,11 +137,12 @@ class SouthernCompanyAPI:
         data = {"ScWebToken": self._sc}
         async with self.session.post(
             "https://customerservice2.southerncompany.com/Account/LoginComplete?"
-            "ReturnUrl=null",
+            "ReturnUrl=/Billing/Home",
             data=data,
+            allow_redirects=False,
         ) as resp:
             # Checking for unsuccessful login
-            if resp.status != 200:
+            if resp.status != 302:
                 await self.authenticate()
                 raise NoScTokenFound(
                     f"Failed to get secondary ScWebToken: {resp.status} "

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -112,7 +112,7 @@ async def test_ga_power_get_jwt_cookie():
         "src.southern_company_api.parser.SouthernCompanyAPI.authenticate"
     ):
         mock_post.return_value = MockResponse(
-            "", 200, ga_power_southern_jwt_cookie_header, ""
+            "", 302, ga_power_southern_jwt_cookie_header, ""
         )
         async with aiohttp.ClientSession() as session:
             sca = SouthernCompanyAPI("", "", session)


### PR DESCRIPTION
Couple things have broken/changed on SC's end.

* `LoginComplete` now 500s on a `null` being sent as the `ReturnUrl`. Send a valid value.
* `LoginComplete` now returns a 302 on success. Cookies are only returned by `aiohttp` for the last request that was followed, so we need to disable following redirects.

I confirmed that error handling for invalid username/password still works as expected.

Resolves https://github.com/Southern-Company-HA/southern-company-hacs/issues/80

cc @Lash-L @dcsim0n